### PR TITLE
NEW AMI ids from CI/CD pipeline

### DIFF
--- a/ci/new-vpc-e2e.json
+++ b/ci/new-vpc-e2e.json
@@ -16,7 +16,7 @@
         "ParameterKey": "DBMasterPassword"
     },
     {
-        "ParameterValue": "override",
+        "ParameterValue": "eqevani-ami",
         "ParameterKey": "KeyPairName"
     },
 
@@ -25,7 +25,7 @@
         "ParameterKey": "BucketName"
     },
     {
-        "ParameterValue": "arn:aws:acm:us-east-1:932770550094:certificate/7b814bab-2f10-4940-9cad-ee8f38422a0c",
+        "ParameterValue": "arn:aws:acm:eu-west-1:932770550094:certificate/44136f73-3cd3-407d-bbea-9b6f8f75eccd",
         "ParameterKey": "CertificateArn"
     }
 ]

--- a/ci/taskcat.yaml
+++ b/ci/taskcat.yaml
@@ -5,7 +5,7 @@ global:
   # N.B.: If you run the tests in a different region than us-east-1,
   # add an override for CertificateArn in ~/.aws/taskcat_global_override.json
   regions:
-    - us-east-1
+    - eu-west-1
   reporting: true
 tests:
   new-vpc-e2e:

--- a/templates/install-xl-platform-existing-vpc.yaml
+++ b/templates/install-xl-platform-existing-vpc.yaml
@@ -177,24 +177,25 @@ Parameters:
 
 Mappings:
   AWSRegionAMI:
-    eu-central-1: 
-      AMIID: ami-0f02453893d0f0e92
-    eu-north-1: 
-      AMIID: ami-0761a64629b2fa0a5
-    eu-west-1: 
-      AMIID: ami-043d1ce25bd418b4b
-    eu-west-2: 
-      AMIID: ami-08b443ee713dbb3d2
-    eu-west-3: 
-      AMIID: ami-08368e6ebbd73da9d
-    us-east-1: 
-      AMIID: ami-04147a0b7a5ea0d32
-    us-east-2: 
-      AMIID: ami-09d455f09c2703830
-    us-west-1: 
-      AMIID: ami-09712ab7ff3e789f8
-    us-west-2: 
-      AMIID: ami-0a8f619eea3ec2241
+    eu-central-1:
+      AMIID: ami-0494af0b101a7169c
+    eu-north-1:
+      AMIID: ami-04aa943b172bbf5a7
+    eu-west-1:
+      AMIID: ami-0d49894c95c6c81ee
+    eu-west-2:
+      AMIID: ami-02c6435995b40df29
+    eu-west-3:
+      AMIID: ami-0741de2558c12b281
+    us-east-1:
+      AMIID: ami-07c6e649617e042b9
+    us-east-2:
+      AMIID: ami-00f237ce4d07aeb36
+    us-west-1:
+      AMIID: ami-0148ea0c555ac4232
+    us-west-2:
+      AMIID: ami-0cecbf82828e9c584
+
 Conditions:
   GovCloudCondition: !Equals [ !Ref "AWS::Region", us-gov-west-1 ]
 Resources:

--- a/templates/install-xl-platform.yaml
+++ b/templates/install-xl-platform.yaml
@@ -189,23 +189,23 @@ Conditions:
 Mappings:
   AWSRegionAMI:
     eu-central-1:
-      AMIID: ami-0f02453893d0f0e92
+      AMIID: ami-0494af0b101a7169c
     eu-north-1:
-      AMIID: ami-0761a64629b2fa0a5
+      AMIID: ami-04aa943b172bbf5a7
     eu-west-1:
-      AMIID: ami-043d1ce25bd418b4b
+      AMIID: ami-0d49894c95c6c81ee
     eu-west-2:
-      AMIID: ami-08b443ee713dbb3d2
+      AMIID: ami-02c6435995b40df29
     eu-west-3:
-      AMIID: ami-08368e6ebbd73da9d
+      AMIID: ami-0741de2558c12b281
     us-east-1:
-      AMIID: ami-04147a0b7a5ea0d32
+      AMIID: ami-07c6e649617e042b9
     us-east-2:
-      AMIID: ami-09d455f09c2703830
+      AMIID: ami-00f237ce4d07aeb36
     us-west-1:
-      AMIID: ami-09712ab7ff3e789f8
+      AMIID: ami-0148ea0c555ac4232
     us-west-2:
-      AMIID: ami-0a8f619eea3ec2241
+      AMIID: ami-0cecbf82828e9c584
 
 Resources:
   VPCStack:


### PR DESCRIPTION
New AMIs eu-central-1: ami-0494af0b101a7169c
eu-north-1: ami-04aa943b172bbf5a7
eu-west-1: ami-0d49894c95c6c81ee
eu-west-2: ami-02c6435995b40df29
eu-west-3: ami-0741de2558c12b281
us-east-1: ami-07c6e649617e042b9
us-east-2: ami-00f237ce4d07aeb36
us-west-1: ami-0148ea0c555ac4232
us-west-2: ami-0cecbf82828e9c584