### PR TITLE
New AMI ids from CI/CD pipeline

### DIFF
--- a/templates/install-xl-platform-existing-vpc.yaml
+++ b/templates/install-xl-platform-existing-vpc.yaml
@@ -189,7 +189,7 @@ Mappings:
     eu-west-3:
       AMIID: ami-04dc46236d6216b85
     us-east-1:
-      AMIID: ami-08cec855957991e8f
+      AMIID: ami-09f23e1ccbba6754b
     us-east-2:
       AMIID: ami-0800eab6d027a79a1
     us-west-1:

--- a/templates/install-xl-platform.yaml
+++ b/templates/install-xl-platform.yaml
@@ -206,7 +206,7 @@ Mappings:
     eu-west-3:
       AMIID: ami-04dc46236d6216b85
     us-east-1:
-      AMIID: ami-08cec855957991e8f
+      AMIID: ami-09f23e1ccbba6754b
     us-east-2:
       AMIID: ami-0800eab6d027a79a1
     us-west-1:


### PR DESCRIPTION
New AMIs [1;32m==> xl-devops-platform-ami: Cleaning up any extra volumes...[0m
[1;32m==> xl-devops-platform-ami: No volumes to clean up, skipping[0m
[1;32m==> xl-devops-platform-ami: Deleting temporary security group...[0m
[1;32m==> xl-devops-platform-ami: Deleting temporary keypair...[0m
[1;32mBuild 'xl-devops-platform-ami' finished.[0m

==> Builds finished. The artifacts of successful builds are:
--> xl-devops-platform-ami: AMIs were created:
us-east-1: ami-08cec855957991e8f